### PR TITLE
Fix Python 3.10 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Recommended:
 
 Approximately 250 MB of free space and 200 MB of memory is needed to run the application using the Tesseract API. If using the Manga OCR model, an additional 450 MB of free space and 800 MB of memory is required.
 
-For developers, the following Python versions are supported: 3.7, 3.8, and 3.9.
+For developers, the following Python versions are supported: 3.7, 3.8, 3.9, and 3.10.
 
 ## Acknowledgements <a name = "acknowledgements"></a>
 This project will not be possible without the MangaOcr model by [Maciej Budyś](https://github.com/kha-white) and the Tesseract python wrapper by [sirfz](https://github.com/sirfz) and [the tesserocr contributors](https://github.com/sirfz/tesserocr/graphs/contributors). 

--- a/code/Ribbon.py
+++ b/code/Ribbon.py
@@ -52,11 +52,11 @@ class RibbonTab(QWidget):
 
     def loadButtonConfig(self, buttonName, buttonConfig):
 
-        w = self.parent.frameGeometry().height(
-        )*config["TBAR_ISIZE_REL"]*buttonConfig["iconW"]
-        h = self.parent.frameGeometry().height(
-        )*config["TBAR_ISIZE_REL"]*buttonConfig["iconH"]
-        m = config["TBAR_ISIZE_MARGIN"]
+        w = int(self.parent.frameGeometry().height(
+        )*config["TBAR_ISIZE_REL"]*buttonConfig["iconW"])
+        h = int(self.parent.frameGeometry().height(
+        )*config["TBAR_ISIZE_REL"]*buttonConfig["iconH"])
+        m = int(config["TBAR_ISIZE_MARGIN"])
 
         icon = QIcon()
         path = config["TBAR_ICONS"] + buttonConfig["path"]
@@ -111,8 +111,8 @@ class Ribbon(QTabWidget):
         self.parent = parent
         self.tracker = tracker
 
-        h = self.parent.frameGeometry().height(
-        ) * config["TBAR_ISIZE_REL"] * config["RBN_HEIGHT"]
+        h = int(self.parent.frameGeometry().height(
+        ) * config["TBAR_ISIZE_REL"] * config["RBN_HEIGHT"])
         self.setFixedHeight(h)
 
         for tabName, tools in config["TBAR_FUNCS"].items():

--- a/code/Views.py
+++ b/code/Views.py
@@ -133,8 +133,8 @@ class OCRCanvas(BaseCanvas):
     def viewImage(self, factor=1):
         # self.verticalScrollBar().setSliderPosition(0)
         factor = self.currentScale
-        w = factor*self.viewport().geometry().width()
-        h = factor*self.viewport().geometry().height()
+        w = int(factor*self.viewport().geometry().width())
+        h = int(factor*self.viewport().geometry().height())
         if self._viewImageMode == 0:
             self.pixmap.setPixmap(
                 self.tracker.pixImage.scaledToWidth(w, Qt.SmoothTransformation))


### PR DESCRIPTION
Force some values to `int` in order to prevent TypeError caused by changes to Python 3.10. (Most likely caused by https://github.com/python/cpython/issues/82180)